### PR TITLE
Fix: deprecation since DMD 2.071

### DIFF
--- a/src/mysql/row.d
+++ b/src/mysql/row.d
@@ -5,6 +5,7 @@ import std.algorithm;
 import std.datetime;
 import std.traits;
 import std.typecons;
+static import std.ascii;
 
 import mysql.exception;
 import mysql.type;


### PR DESCRIPTION
See http://dlang.org/changelog/2.071.0.html#imports-313
fully qualified name was used to bypass private import of std.ascii
