### PR TITLE
Remove deprecation notice by adding required import.

### DIFF
--- a/src/mysql/row.d
+++ b/src/mysql/row.d
@@ -6,6 +6,7 @@ import std.datetime;
 import std.traits;
 import std.typecons;
 static import std.ascii;
+import std.format : format;
 
 import mysql.exception;
 import mysql.type;


### PR DESCRIPTION
Using newer version of DMD caused the deprecation notice "Deprecation: mysql.type.format is not visible from module row" to be shown. This imports the required module so that the notice is removed.
