### PR TITLE
Remove unnecessary skip(1) handling OK packet.

### DIFF
--- a/src/mysql/connection.d
+++ b/src/mysql/connection.d
@@ -711,11 +711,9 @@ private:
 
 			if (!packet.empty && (caps_ & CapabilityFlags.CLIENT_SESSION_TRACK)) {
 				info(packet.eat!(const(char)[])(cast(size_t)packet.eatLenEnc()));
-				packet.skip(1);
 
 				if (status_.flags & StatusFlags.SERVER_SESSION_STATE_CHANGED) {
 					packet.skip(cast(size_t)packet.eatLenEnc());
-					packet.skip(1);
 				}
 			}
 


### PR DESCRIPTION
`conn.execute("update users set del_flg = 0")` raises AssertError like this:

```
update users set del_flg = 0
core.exception.AssertError@../../../.dub/packages/mysql-lited-0.3.17/mysql-lited/src/mysql/packet.d(53):
Assertion failure
----------------
??:? _d_assertp [0x1d338c99]
??:? void mysql.packet.InputPacket.skip(ulong) [0x1d286425]
??:? void
mysql.connection.__T10ConnectionTS5mysql6socket10VibeSocketVE5mysql10connection17ConnectionOptionsi0Z.Connection.eatStatus!("source/app.d",
17uL).eatStatus(mysql.packet.InputPacket, bool) [0x1d270f62]
??:? void
mysql.connection.__T10ConnectionTS5mysql6socket10VibeSocketVE5mysql10connection17ConnectionOptionsi0Z.Connection.execute!("source/app.d",
17uL).execute(mysql.connection.PreparedStatement) [0x1d272e6d]
??:? void
mysql.connection.__T10ConnectionTS5mysql6socket10VibeSocketVE5mysql10connection17ConnectionOptionsi0Z.Connection.execute!("source/app.d",
17).execute(const(char)[]) [0x1d270b36]
...
Program exited with code 1
```

It seems that we should not skip 1 byte, so I remove it.

ref: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_ok_packet.html