### PR TITLE
Add support for vibe-core

### DIFF
--- a/src/mysql/socket.d
+++ b/src/mysql/socket.d
@@ -20,7 +20,9 @@ struct VibeSocket {
 	void close() {
 		if (socket_) {
 			socket_.close();
-			socket_ = null;
+			static if (is(typeof(socket_) == class)) {
+				socket_ = null;
+			}
 		}
 	}
 
@@ -93,6 +95,10 @@ struct VibeSocket {
 	}
 
 private:
+	import vibe.core.stream;
 	TCPConnection socket_;
-	Stream stream_;
+	static if (is(StreamProxy))
+		StreamProxy stream_;
+	else
+		Stream stream_;
 }


### PR DESCRIPTION
mysql-lited does not work with latest vibe-d when using vibe-core as subConfiguration for vibed:core